### PR TITLE
fix options[:force] lost

### DIFF
--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -107,8 +107,9 @@ module Elasticsearch
             else
               errors = Hash.new
               I18n.available_locales.each do |locale|
+                super_options = options.clone
                 ::Globalize.with_locale(locale) do
-                  errors[locale] = super(options, &block)
+                  errors[locale] = super(super_options, &block)
                 end
               end
               self.find_each do |record|


### PR DESCRIPTION
when import with option force, the option force will lost start from the second loop of the locales each.
