### PR TITLE
Fix rake task index creation exception

### DIFF
--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -225,7 +225,10 @@ module Elasticsearch
           common_changed_attributes = Hash[ changes.map{ |key, value| [key, value.last] } ]
           translated_attribute_names.each { |k| common_changed_attributes.delete(k) }
 
-          globalize.stash.reject{ |locale, attrs| attrs.empty? }.each do |locale, attrs|
+          stash = globalize.stash
+          stash = stash.reject{ |locale, attrs| attrs.empty? } if common_changed_attributes.empty?
+
+          stash.each do |locale, attrs|
             __elasticsearch__.changed_attributes_by_locale[locale] = attrs.merge(common_changed_attributes)
           end
           true

--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -105,11 +105,11 @@ module Elasticsearch
             if current_locale_only
               super(options, &block)
             else
-              errors = Hash.new
+              total_errors = 0
               I18n.available_locales.each do |locale|
                 super_options = options.clone
                 ::Globalize.with_locale(locale) do
-                  errors[locale] = super(super_options, &block)
+                  total_errors += super(super_options, &block)
                 end
               end
               self.find_each do |record|
@@ -119,7 +119,7 @@ module Elasticsearch
                   end
                 end
               end
-              errors
+              total_errors
             end
           end
         end


### PR DESCRIPTION
Return the total errors count when using one index per locale

This change fixes

```
NoMethodError: undefined method `zero?' for {:en=>0, :ro=>0}:Hash
gems/elasticsearch-rails-0.1.8/lib/elasticsearch/rails/tasks/import.rb:74:in `block (3 levels) in <top (required)>'
```

Related to https://github.com/elastic/elasticsearch-rails/commit/a09ec4a4b627b589e349dffa8b1c2cf2b70abf88#diff-77bc7d336cef089f94fa9ceadf38a1c0
