### PR TITLE
Different index names for all available locales

### DIFF
--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -113,6 +113,7 @@ module Elasticsearch
                   errors[locale] = super(super_options, &block)
                 end
               end
+              super(options, &block)
               self.find_each do |record|
                 (I18n.available_locales - record.translations.pluck(:locale).map(&:to_sym)).each do |locale|
                   ::Globalize.with_locale(locale) do

--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -117,7 +117,7 @@ module Elasticsearch
               self.find_each do |record|
                 (I18n.available_locales - record.translations.pluck(:locale).map(&:to_sym)).each do |locale|
                   ::Globalize.with_locale(locale) do
-                    record.__elasticsearch__.delete_document(current_locale_only: true)
+                    # record.__elasticsearch__.delete_document(current_locale_only: true)
                   end
                 end
               end

--- a/lib/elasticsearch/model/globalize/one_index_per_language.rb
+++ b/lib/elasticsearch/model/globalize/one_index_per_language.rb
@@ -108,6 +108,7 @@ module Elasticsearch
               errors = Hash.new
               I18n.available_locales.each do |locale|
                 super_options = options.clone
+                super_options[:index] = "#{self.index_name}-#{locale}".downcase
                 ::Globalize.with_locale(locale) do
                   errors[locale] = super(super_options, &block)
                 end

--- a/lib/elasticsearch/model/globalize/version.rb
+++ b/lib/elasticsearch/model/globalize/version.rb
@@ -1,7 +1,7 @@
 module Elasticsearch
   module Model
     module Globalize
-      VERSION = "0.0.3"
+      VERSION = "0.0.4"
     end
   end
 end


### PR DESCRIPTION
Implemented functionality will enable gem to create different indexes for each available locale. 
Example indexes created for :en and :de locales:
some_base_index_name-en
some_base_index_name-de
